### PR TITLE
Mprpc instead of msgpack rpc python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
   - rbenv global 2.3.1
   - gem install bundler
   - bundle
-  - pip install mprpc
+  - pip install --user mprpc
 script: python -m unittest discover -v
 cache:
   bundler: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "3.5"
   - "3.6"
 install:
   - git clone https://github.com/rbenv/rbenv.git ~/.rbenv
@@ -12,7 +11,7 @@ install:
   - rbenv global 2.3.1
   - gem install bundler
   - bundle
-  - pip install --user mprpc
+  - pip install mprpc
 script: python -m unittest discover -v
 cache:
   bundler: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - "3.5"
+  - "3.6"
 install:
   - git clone https://github.com/rbenv/rbenv.git ~/.rbenv
   - echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.bash_profile
@@ -11,7 +12,7 @@ install:
   - rbenv global 2.3.1
   - gem install bundler
   - bundle
-  - pip install --user msgpack-rpc-python
+  - pip install mprpc
 script: python -m unittest discover -v
 cache:
   bundler: true

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Use Python 3 and then install the following dependencies.
 Please note that msgpack-rpc-python does not work well with msgpack-python 0.5 or later.
 
 ```
-pip install msgpack-python==0.4.8 msgpack-rpc-python==0.4.1
+pip install mprpc
 ```
 
 Execute a sample script.

--- a/rb_call.py
+++ b/rb_call.py
@@ -104,7 +104,9 @@ class RubySession:
         atexit.register( cleanup )
         port = int( self.proc.stdout.readline() )
         self.proc.stdout.close()
-        self.client = mprpc.RPCClient('localhost', port)
+        def default(obj):
+            return obj.to_msgpack()
+        self.client = mprpc.RPCClient('localhost', port, pack_params = {"default": default} )
         RubyObject.session = self
         self.kernel = RubyObject.cast( self.client.call('get_kernel') )
 

--- a/rb_call.py
+++ b/rb_call.py
@@ -59,9 +59,10 @@ class RubyObject():
             obj = self.session.client.call('send_method', self.obj_id, method, args, kwargs )
             return self.cast(obj)
         except mprpc.exceptions.RPCError as ex:
-            matched = re.match(r'ExtType\(code=40, data=b\'(\S*)\'\)', ex.args[0])
+            # data may contain space, single-quote('), double-quote(")
+            matched = re.match(r'ExtType\(code=40, data=b(.+)\)', ex.args[0])
             if matched:
-                e = msgpack.ExtType(40, eval('b\''+matched.group(1)+'\'') )
+                e = msgpack.ExtType(40, eval('b'+matched.group(1)) )
                 arg = RubyObject.cast( e )
                 raise RubyException( arg.message(), arg ) from None
             else:

--- a/rb_call.py
+++ b/rb_call.py
@@ -106,7 +106,7 @@ class RubySession:
         self.proc.stdout.close()
         def default(obj):
             return obj.to_msgpack()
-        self.client = mprpc.RPCClient('localhost', port, pack_encoding= None, unpack_encoding=None, pack_params = {"default": default} )
+        self.client = mprpc.RPCClient('localhost', port, pack_encoding= None, unpack_encoding=None, pack_params = {"default": default}, unpack_params={"raw":False})
         RubyObject.session = self
         self.kernel = RubyObject.cast( self.client.call('get_kernel') )
 

--- a/rb_call.py
+++ b/rb_call.py
@@ -9,7 +9,7 @@ class RubyObject():
     def cast(obj):
         if isinstance( obj, msgpack.ExtType ):
             assert obj.code == 40
-            rb_class, obj_id = msgpack.unpackb(obj.data, encoding='utf-8')
+            rb_class, obj_id = msgpack.unpackb(obj.data, raw=False)
             return RubyObject( rb_class, obj_id )
         elif isinstance( obj, list ):
             return [ RubyObject.cast(x) for x in obj ]
@@ -106,7 +106,7 @@ class RubySession:
         self.proc.stdout.close()
         def default(obj):
             return obj.to_msgpack()
-        self.client = mprpc.RPCClient('localhost', port, pack_params = {"default": default} )
+        self.client = mprpc.RPCClient('localhost', port, pack_encoding= None, unpack_encoding=None, pack_params = {"default": default} )
         RubyObject.session = self
         self.kernel = RubyObject.cast( self.client.call('get_kernel') )
 


### PR DESCRIPTION
Replace messagepack-rpy-python with mprpc since the former has not been updated for a while.
