### PR TITLE
Revert "replace msgpack-rpc-python with mprpc" - mprpc does not install on Python 3.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ bundle
 Use Python 3 and then install the following dependencies.
 
 ```
-pip install mprpc
+pip install msgpack-rpc-python
 ```
 
 To verify the installation, execute a sample script.


### PR DESCRIPTION
This reverts commit de35f64158dcc54477de0910516d7f91cc418ee7.

Unfortunately, the mprpc package fails to install with Python 3.11.x most probably because of the changes in Cython.

```
  × Building wheel for mprpc (pyproject.toml) did not run successfully.
  │ exit code: 1
  [...]
        mprpc/client.c:181:12: fatal error: longintrepr.h: No such file or directory
        181 |   #include "longintrepr.h"
            |            ^~~~~~~~~~~~~~~
      compilation terminated.
```

The solution would be to update the package, but it is no longer developed. The GitHub repository for mprpc project (https://github.com/studio-ousia/mprpc) got archived by the owner on Dec 27, 2022:

>  NOTICE: This library is not actively maintained. Please consider
>  using other alternatives such as gRPC.

There are other Python packages for MessagePack RPC than msgpack-rpc-python and mprpc, but they have their own problems.

- gRPC is heavily into *.proto files as universal cross-language interface definition, and would require rewriting rb_call
- aiorpc is under developed (4 - Beta), and should not to be considered to have a stable API; additionally, the README says that benchmarks show that it slightly underperforms official MessagePack RPC (0.7x slower)
- rpc-msgpack claims to be updated version for MessagePack RPC for Python, but its PyPI page (https://pypi.org/project/rpc-msgpack/) is very sparse on details
- tinyrpc now supports MessagePack (`tinyprc[msgpack]`), but it was originally JSON-RPC and ZMQ library; it looks like most actively developed beside gRPC
- txmsgpackrpc repository was archived on May 31, 2022
- msgpack-rpc-python (MessagePack RPC for Python) got its last release on Mar 14, 2018 - but as pure Python package has no problems being installed with Python 3.11
- lotrpc is in 3 - Alpha, last release from Jan 23, 2020; repo archived on Aug 5, 2023
- spyne is transport and architecture agnostic rpc library; last release 2022 but I'm not sure if it is a good match for rb_call: no support for plan RPC

It looks like best replacement would be tinyrpc, assuming that is performance is not worse than msgpack-rpc-python... but it would require some changes (though not as much as switching to gRPC would).